### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/SensorColor.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/SensorColor.java
@@ -153,7 +153,7 @@ public class SensorColor extends LinearOpMode {
       // Update the gain value if either of the A or B gamepad buttons is being held
       if (gamepad1.a) {
         // Only increase the gain by a small amount, since this loop will occur multiple times per second.
-        gain += 0.005;
+        gain += 0.005f;
       } else if (gamepad1.b && gain > 1) { // A gain of less than 1 will make the values smaller, which is not helpful.
         gain -= 0.005;
       }


### PR DESCRIPTION
Fixes [https://github.com/canbycougarbots7878/FTC-Code/security/code-scanning/1](https://github.com/canbycougarbots7878/FTC-Code/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the right-hand side of the compound assignment matches the type of the left-hand side. Since `gain` is a `float`, we should use a `float` literal for the value `0.005`. In Java, this can be done by appending an `f` to the literal, making it `0.005f`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
