### PR TITLE
Fix code scanning alert no. 2: Implicitly exported Android component

### DIFF
--- a/FtcRobotController/src/main/AndroidManifest.xml
+++ b/FtcRobotController/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
       android:screenOrientation="fullUser"
       android:configChanges="orientation|screenSize"
       android:label="@string/app_name"
-      android:launchMode="singleTask" >
+      android:launchMode="singleTask"
+      android:exported="false" >
 
       <intent-filter>
         <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />


### PR DESCRIPTION
Fixes [https://github.com/canbycougarbots7878/FTC-Code/security/code-scanning/2](https://github.com/canbycougarbots7878/FTC-Code/security/code-scanning/2)

To fix the problem, we need to explicitly set the `android:exported` attribute for the `<activity>` tag on line 36. This will ensure that the component's export status is clearly defined and not left to default behavior, which can pose security risks. We should set `android:exported` to `false` if the component is not intended to be accessible by other applications, or to `true` if it is intended to be accessible.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
